### PR TITLE
day 142 fix: Thank you Alex! @alexfjw

### DIFF
--- a/day142/problem.go
+++ b/day142/problem.go
@@ -3,24 +3,32 @@ package day142
 // WildcardParens answers if the parens are balanced.
 // This includes a wildcard character '*' that can be either paren
 // or an empty string.
+// Implementation note: counts opens two different ways.
+// First, it counts opens assuming a wildcard is an open '('.
+// Next, it counts opens assuming a wildcard is a close ')'.
+// Runs in O(N) time and O(1) space.
 func WildcardParens(input string) bool {
-	var opens, wildcards int
+	var opensIfWildcardCloses, opensIfWildcardOpens int
 	for _, c := range input {
 		switch c {
 		case '(':
-			opens++
+			opensIfWildcardCloses++
+			opensIfWildcardOpens++
 		case ')':
-			switch {
-			case opens == 0 && wildcards < 1:
-				return false
-			case opens == 0:
-				wildcards--
-			default:
-				opens--
-			}
+			opensIfWildcardCloses--
+			opensIfWildcardOpens--
 		case '*':
-			wildcards++
+			opensIfWildcardCloses--
+			opensIfWildcardOpens++
+		}
+		if opensIfWildcardOpens < 0 {
+			break
+		}
+		// if a closing wildcard goes negative,
+		// assume it's an empty string.
+		if opensIfWildcardCloses < 0 {
+			opensIfWildcardCloses = 0
 		}
 	}
-	return opens == 0 || opens <= wildcards
+	return opensIfWildcardCloses == 0
 }

--- a/day142/problem_test.go
+++ b/day142/problem_test.go
@@ -2,6 +2,7 @@ package day142
 
 import "testing"
 
+// nolint
 var testcases = []struct {
 	input    string
 	balanced bool
@@ -17,6 +18,7 @@ var testcases = []struct {
 	{"***********************", true},
 	{"****)))", true},
 	{"****)))))", false},
+	{"*(", false},
 }
 
 func TestWildcardParens(t *testing.T) {


### PR DESCRIPTION
Thanks to @alexfjw for pointing out a test case that fails for my solution. 🙇 
https://github.com/vaskoz/dailycodingproblem-go/issues/297#issuecomment-508896291

Specifically, `*(` failed in my solution because it didn't account for the position for the wildcard being before the open brace.

My new solution calculates the number of opening braces in two different ways. First, assuming that wildcards are just opening braces. Second, assuming that wildcards are just closing braces.

If wildcard closing braces goes negative, assuming they're empty strings instead.

Unfortunately, this correct solution is twice as slow as my first version.
```
goos: darwin
goarch: amd64
pkg: github.com/vaskoz/dailycodingproblem-go/day142
BenchmarkWildcardParens-12    	   50000	     25021 ns/op
```
versus
```
goos: darwin
goarch: amd64
pkg: github.com/vaskoz/dailycodingproblem-go/day142
BenchmarkWildcardParens-12    	  100000	     12708 ns/op
```